### PR TITLE
Implement socket mail sending with DKIM/SPF stubs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,16 +68,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>javax.mail-api</artifactId>
-			<version>1.5.5</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-			<version>1.4.7</version>
-		</dependency>
-		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>1.18.24</version>

--- a/src/main/java/common/mailServer/config/PropertiesConfig.java
+++ b/src/main/java/common/mailServer/config/PropertiesConfig.java
@@ -1,10 +1,14 @@
 package common.mailServer.config;
 
 import common.mailServer.properties.FileProperties;
+import common.mailServer.properties.ProtocolTimeoutProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = {FileProperties.class})
+@EnableConfigurationProperties(value = {
+        FileProperties.class,
+        ProtocolTimeoutProperties.class
+})
 public class PropertiesConfig {
 }

--- a/src/main/java/common/mailServer/mail/sender/socket/DkimUtil.java
+++ b/src/main/java/common/mailServer/mail/sender/socket/DkimUtil.java
@@ -1,0 +1,20 @@
+package common.mailServer.mail.sender.socket;
+
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.util.Base64;
+
+/**
+ * 간단한 DKIM 서명 유틸리티.
+ * 실제 DKIM 스펙을 완벽히 구현하지는 않으며 샘플용으로 사용한다.
+ */
+public class DkimUtil {
+    public static String sign(String data, PrivateKey key) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        Signature sig = Signature.getInstance("SHA256withRSA");
+        sig.initSign(key);
+        sig.update(data.getBytes(StandardCharsets.UTF_8));
+        byte[] signed = sig.sign();
+        return Base64.getEncoder().encodeToString(signed);
+    }
+}
+

--- a/src/main/java/common/mailServer/mail/sender/socket/SimpleSmtpSocketClient.java
+++ b/src/main/java/common/mailServer/mail/sender/socket/SimpleSmtpSocketClient.java
@@ -1,0 +1,64 @@
+package common.mailServer.mail.sender.socket;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * SMTP 서버와 소켓 통신을 통해 메일을 전송하는 간단한 클라이언트.
+ * 프로토콜별 소켓 타임아웃 설정을 위해 생성자에서 timeout 값을 전달받아 사용한다.
+ */
+public class SimpleSmtpSocketClient {
+    private final String host;
+    private final int port;
+    private final int connectTimeout;
+    private final int readTimeout;
+
+    public SimpleSmtpSocketClient(String host, int port, int connectTimeout, int readTimeout) {
+        this.host = host;
+        this.port = port;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+    }
+
+    /**
+     * 기본적인 SMTP 통신 과정을 통해 메일을 전송한다.
+     * 실제 환경에서는 인증 과정과 TLS 처리가 필요하다.
+     */
+    public void send(String from, String to, String data) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), connectTimeout);
+            socket.setSoTimeout(readTimeout);
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+
+            // 연결 확인
+            reader.readLine();
+            writer.write("HELO " + host + "\r\n");
+            writer.flush();
+            reader.readLine();
+
+            writer.write("MAIL FROM:<" + from + ">\r\n");
+            writer.flush();
+            reader.readLine();
+
+            writer.write("RCPT TO:<" + to + ">\r\n");
+            writer.flush();
+            reader.readLine();
+
+            writer.write("DATA\r\n");
+            writer.flush();
+            reader.readLine();
+
+            writer.write(data);
+            writer.write("\r\n.\r\n");
+            writer.flush();
+            reader.readLine();
+
+            writer.write("QUIT\r\n");
+            writer.flush();
+        }
+    }
+}
+

--- a/src/main/java/common/mailServer/mail/sender/socket/SocketMailService.java
+++ b/src/main/java/common/mailServer/mail/sender/socket/SocketMailService.java
@@ -1,0 +1,36 @@
+package common.mailServer.mail.sender.socket;
+
+import common.mailServer.properties.ProtocolTimeoutProperties;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SignatureException;
+
+/**
+ * 소켓을 이용하여 메일을 전송하기 위한 서비스.
+ * DKIM 서명과 SPF 검사를 수행한 뒤 메일을 전송한다.
+ */
+public class SocketMailService {
+    private final SimpleSmtpSocketClient smtpClient;
+
+    public SocketMailService(String host, int port, ProtocolTimeoutProperties.Protocol timeout) {
+        this.smtpClient = new SimpleSmtpSocketClient(host, port, timeout.getConnect(), timeout.getRead());
+    }
+
+    public void send(String from, String to, String data, PrivateKey dkimKey)
+            throws IOException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        // DKIM 서명 생성 (샘플)
+        String signature = DkimUtil.sign(data, dkimKey);
+        StringBuilder builder = new StringBuilder();
+        builder.append("DKIM-Signature: ").append(signature).append("\r\n");
+        builder.append(data);
+
+        // SPF 확인 (실제 구현 필요)
+        SpfUtil.checkSpf(from.substring(from.indexOf('@') + 1), "0.0.0.0");
+
+        smtpClient.send(from, to, builder.toString());
+    }
+}
+

--- a/src/main/java/common/mailServer/mail/sender/socket/SpfUtil.java
+++ b/src/main/java/common/mailServer/mail/sender/socket/SpfUtil.java
@@ -1,0 +1,13 @@
+package common.mailServer.mail.sender.socket;
+
+/**
+ * SPF 검사 유틸리티의 간단한 골격.
+ * DNS 조회가 필요한 부분은 실제 구현에서 추가해야 한다.
+ */
+public class SpfUtil {
+    public static boolean checkSpf(String domain, String ipAddress) {
+        // TODO: DNS SPF 레코드 조회 후 IP 확인 로직 구현
+        return true;
+    }
+}
+

--- a/src/main/java/common/mailServer/properties/ProtocolTimeoutProperties.java
+++ b/src/main/java/common/mailServer/properties/ProtocolTimeoutProperties.java
@@ -1,0 +1,24 @@
+package common.mailServer.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@ConstructorBinding
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "protocol.timeout")
+public class ProtocolTimeoutProperties {
+    private final Protocol smtp;
+    private final Protocol imap;
+    private final Protocol pop3;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static final class Protocol {
+        private final int connect;
+        private final int read;
+    }
+}
+

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -13,3 +13,9 @@ upload.baseDir=d:\\upload\\
 logging.level.web = debug
 
 origin.address = http://localhost:8080
+protocol.timeout.smtp.connect=5000
+protocol.timeout.smtp.read=5000
+protocol.timeout.imap.connect=5000
+protocol.timeout.imap.read=5000
+protocol.timeout.pop3.connect=5000
+protocol.timeout.pop3.read=5000

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -13,3 +13,9 @@ upload.baseDir=d:\\upload\\
 logging.level.web = debug
 
 origin.address = http://localhost:8080
+protocol.timeout.smtp.connect=5000
+protocol.timeout.smtp.read=5000
+protocol.timeout.imap.connect=5000
+protocol.timeout.imap.read=5000
+protocol.timeout.pop3.connect=5000
+protocol.timeout.pop3.read=5000

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -15,4 +15,12 @@ logging.level.web = debug
 
 origin.address = https://mail-server.miocat.synology.me
 
+protocol.timeout.smtp.connect=5000
+protocol.timeout.smtp.read=5000
+protocol.timeout.imap.connect=5000
+protocol.timeout.imap.read=5000
+protocol.timeout.pop3.connect=5000
+protocol.timeout.pop3.read=5000
+
+
 


### PR DESCRIPTION
## Summary
- remove JavaMail dependencies
- add socket-based mail sender classes with DKIM and SPF stubs
- enable protocol timeout configuration
- add protocol timeout properties in configs

## Testing
- `./mvnw -q test` *(fails: maven wrapper requires network access)*